### PR TITLE
Update to 1.6.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ gst-plugins-ugly-1.4.5.tar.xz
 gst-plugins-ugly-1.6.1.tar.xz
 gst-plugins-ugly-1.6.2.tar.xz
 gst-plugins-ugly-1.6.3.tar.xz
+gst-plugins-ugly-1.6.4.tar.xz

--- a/gstreamer1-plugins-ugly.spec
+++ b/gstreamer1-plugins-ugly.spec
@@ -1,6 +1,6 @@
 Summary:        GStreamer 1.0 streaming media framework "ugly" plug-ins
 Name:           gstreamer1-plugins-ugly
-Version:        1.6.3
+Version:        1.6.4
 Release:        1%{?dist}
 License:        LGPLv2+
 Group:          Applications/Multimedia
@@ -72,7 +72,8 @@ rm $RPM_BUILD_ROOT%{_libdir}/gstreamer-1.0/*.la
 
 
 %files -f gst-plugins-ugly-1.0.lang
-%doc AUTHORS COPYING README REQUIREMENTS
+%doc AUTHORS README REQUIREMENTS
+%license COPYING
 %{_datadir}/gstreamer-1.0
 # Plugins without external dependencies
 %{_libdir}/gstreamer-1.0/libgstasf.so
@@ -98,6 +99,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/gstreamer-1.0/*.la
 
 
 %changelog
+* Sat May 21 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.6.4-1
+- Update to 1.6.4
+
 * Sat Jan 23 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.6.3-1
 - Rebase to new upstream release 1.6.3
 

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-dbd92afb3816cbfa90ab1f197144a2e2  gst-plugins-ugly-1.6.3.tar.xz
+1acdb29ede2e72bed4e7c6714a6aac5c  gst-plugins-ugly-1.6.4.tar.xz


### PR DESCRIPTION
Update rpmfusion gstreamer1-\* f23 packages to 1.6.4, to bring them in sync with their Fedora counterparts.

tarbals have been uploaded to the look-a-side cache already.
