### PR TITLE
Rebase to new upstream release 1.8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ gst-plugins-ugly-1.6.1.tar.xz
 gst-plugins-ugly-1.6.2.tar.xz
 gst-plugins-ugly-1.6.3.tar.xz
 gst-plugins-ugly-1.8.1.tar.xz
+gst-plugins-ugly-1.8.2.tar.xz

--- a/gstreamer1-plugins-ugly.spec
+++ b/gstreamer1-plugins-ugly.spec
@@ -1,6 +1,6 @@
 Summary:        GStreamer 1.0 streaming media framework "ugly" plug-ins
 Name:           gstreamer1-plugins-ugly
-Version:        1.8.1
+Version:        1.8.2
 Release:        1%{?dist}
 License:        LGPLv2+
 Group:          Applications/Multimedia
@@ -52,9 +52,6 @@ be shipped in gstreamer-plugins-good because:
 
 %prep
 %setup -q -n gst-plugins-ugly-%{version}
-# hack to allow building against 1.6.0 as 1.6.3 is not yet in the buildroot
-sed -i 's/GST_REQ=1.6.3/GST_REQ=1.6.0/' configure
-sed -i 's/GSTPB_REQ=1.6.3/GSTPB_REQ=1.6.0/' configure
 
 
 %build
@@ -101,6 +98,9 @@ rm $RPM_BUILD_ROOT%{_libdir}/gstreamer-1.0/*.la
 
 
 %changelog
+* Sun Jun 12 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.8.2-1
+- Rebase to new upstream release 1.8.2
+
 * Wed May 18 2016 Hans de Goede <j.w.r.degoede@gmail.com> - 1.8.1-1
 - Rebase to new upstream release 1.8.1
 

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-b6f47bcb3d924f7ef8a8b33ac4d037ab  gst-plugins-ugly-1.8.1.tar.xz
+f781790cf64b44522b01ab560f16d4de  gst-plugins-ugly-1.8.2.tar.xz


### PR DESCRIPTION
Update rpmfusion gstreamer pkgs to 1.8.2, to bring them in sync with F24, tarballs have already been uploaded to the (old) look-a-side cache.
